### PR TITLE
Replaced or removed jars with vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM eclipse-temurin:11-jammy
+FROM eclipse-temurin:17-jammy
 
-ENV SPARK_VERSION=3.4.2
-ENV CDM_VERSION=4.1.12
+ENV CDM_VERSION=4.1.12 \
+    SPARK_VERSION=3.4.2 \
+    SCALA_VERSION=2.13.12 \
+    ZOOKEEPER_VERSION=3.8.3 \
+    SNAKEYAML_VERSION=2.0
 
 # Install Spark
 WORKDIR /install
@@ -12,6 +15,36 @@ RUN curl -OL https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-
     tar -xzf ./spark-${SPARK_VERSION}-bin-hadoop3-scala2.13.tgz && \
     mv ./spark-${SPARK_VERSION}-bin-hadoop3-scala2.13 $SPARK_HOME && \
     rm ./spark-${SPARK_VERSION}-bin-hadoop3-scala2.13.tgz
+
+# The following libraries packaged with Spark have critical vulnerabilities, so upgrade to a new version or remove them
+#  - scala-library 2.13.8 -> upgrade
+#  - scala-compiler 2.13.8 -> upgrade
+#  - jackson-mapper-asl 1.9.13 -> remove
+#  - derby 10.14.2.0 -> remove
+#  - zookeeper 3.6.3 -> upgrade
+#  - snakeyaml 1.33 -> upgrade
+RUN curl -OL https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz && \
+    tar -xzf ./scala-${SCALA_VERSION}.tgz && \
+    rm ${SPARK_HOME}/jars/scala-library-*.jar && \
+    rm ${SPARK_HOME}/jars/scala-compiler-*.jar && \
+    cp ./scala-${SCALA_VERSION}/lib/scala-library.jar ${SPARK_HOME}/jars/scala-library-${SCALA_VERSION}.jar && \
+    cp ./scala-${SCALA_VERSION}/lib/scala-compiler.jar ${SPARK_HOME}/jars/scala-compiler-${SCALA_VERSION}.jar && \
+    rm -r ./scala-${SCALA_VERSION} && \
+    rm ./scala-${SCALA_VERSION}.tgz
+
+RUN rm ${SPARK_HOME}/jars/jackson-mapper-asl-*.jar
+
+RUN rm ${SPARK_HOME}/jars/derby-*.jar
+
+RUN curl -OL https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/${ZOOKEEPER_VERSION}/zookeeper-${ZOOKEEPER_VERSION}.jar && \
+    curl -OL https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper-jute/${ZOOKEEPER_VERSION}/zookeeper-jute-${ZOOKEEPER_VERSION}.jar && \
+    rm ${SPARK_HOME}/jars/zookeeper-*.jar && \
+    mv ./zookeeper-${ZOOKEEPER_VERSION}.jar ${SPARK_HOME}/jars/zookeeper-${ZOOKEEPER_VERSION}.jar && \
+    mv ./zookeeper-jute-${ZOOKEEPER_VERSION}.jar ${SPARK_HOME}/jars/zookeeper-jute-${ZOOKEEPER_VERSION}.jar
+
+RUN curl -OL https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKEYAML_VERSION}/snakeyaml-${SNAKEYAML_VERSION}.jar && \
+    rm ${SPARK_HOME}/jars/snakeyaml-*.jar && \
+    mv ./snakeyaml-${SNAKEYAML_VERSION}.jar ${SPARK_HOME}/jars/snakeyaml-${SNAKEYAML_VERSION}.jar
 
 ENV PATH=$PATH:${SPARK_HOME}/bin
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,11 @@ set_operating_file_values() {
     done
 }
 
+info "Setting up Cassandra Data Migrator $CDM_VERSION"
+info "Using Java $JAVA_VERSION"
+info "Using Spark $SPARK_VERSION"
+info "Using Scala $SCALA_VERSION"
+
 set_operating_file_values "$CDM_PROPERTIES_FILE" "CDM_PROPERTY_" ""
 set_operating_file_values "$CDM_LOG4J_CONFIGURATION" "CDM_LOGGING_" "="
 


### PR DESCRIPTION
* Upgraded Java to open-jdk 17 by changing eclipse-temurin base image in Dockerfil from jammy-11 to jammy-17
* Added commands to Dockerfile to replace the following libraries packaged with Spark that have critical vulnerabilities:
  - scala-library 2.13.8 -> 2.13.12
  - scala-compiler 2.13.8 -> 2.13.12
  - zookepper 3.6.3 -> 3.8.3
  - snakeyaml 1.33 -> 2.0
* Added commands to Dockerfile to remove the following libraries packaged with Spark that have critical vulnerabiliies:
  - derby 10.14.2.0
  - jackson-mapper-asl 1.9.13
* Add info logging to entrypoint.sh to display Java, Spark and Scala version in use