### PR TITLE
Bug fixes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,8 +78,9 @@ set_operating_file_values() {
   info "Updating settings in $file_path"
   for env_var in ${env_config_values[*]}
   do
-    conf_key=$(cut -d'=' -f1 <<<"${env_var/$env_var_prefix/}" | tr '[:upper:]' '[:lower:]' | tr '_' '.')
-    new_conf_val="${env_var/*=/}"
+    env_var_key=$(cut -d'=' -f1 <<<"${env_var/$env_var_prefix/}")
+    conf_key=$(tr '[:upper:]' '[:lower:]' <<<"$env_var_key" | tr '_' '.')
+    new_conf_val=${env_var/${env_var_prefix}${env_var_key}=/}
 
     temp_conf_val=""
     if [ "${new_conf_val:0:4}" = "env:" ]

--- a/log4j.properties
+++ b/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootLogger=INFO,file
 
 # Define console appender
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-logrj.appender.console.Target=System.out
+log4j.appender.console.Target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [THREAD ID=%t] %c{1}:%L %logger{36} - %msg%n
 


### PR DESCRIPTION
* Fixed entrypoint to allow an environment variable specifying a filter.cassandra.wherecondition containing an equals sign to be inserted correctly into the cdm properties file.
* Fixed typo in log4j.properties file.